### PR TITLE
Change to end of line and replace character

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,10 @@ func main() {
 - `V`: Enter visual line mode
 - `:`: Enter command mode
 - `x`: Delete character at cursor
+- `r`: Replace character at cursor
 - `dd`: Delete line
 - `D`: Delete from cursor to end of line
+- `C`: Change from cursor to end of line
 - `yy`: Yank (copy) line
 - `p`: Paste after cursor
 - `P`: Paste before cursor

--- a/commands.go
+++ b/commands.go
@@ -73,6 +73,7 @@ func registerBindings(m *editorModel) {
 	m.registry.Add("yy", yankLine, ModeNormal, "Yank line")
 	m.registry.Add("dd", deleteLine, ModeNormal, "Delete line")
 	m.registry.Add("D", deleteToEndOfLine, ModeNormal, "Delete to end of line")
+	m.registry.Add("C", changeToEndOfLine, ModeNormal, "Change to end of line")
 	m.registry.Add("p", pasteAfter, ModeNormal, "Paste after cursor")
 	m.registry.Add("P", pasteBefore, ModeNormal, "Paste before cursor")
 
@@ -160,6 +161,11 @@ func moveToFirstNonWhitespace(model *editorModel) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+func changeToEndOfLine(model *editorModel) tea.Cmd {
+	_ = deleteToEndOfLine(model)
+	return enterModeInsert(model)
 }
 
 func deleteToEndOfLine(model *editorModel) tea.Cmd {

--- a/model.go
+++ b/model.go
@@ -105,6 +105,7 @@ type editorModel struct {
 	lastBlinkTime   time.Time      // Time of last cursor blink
 	blinkInterval   time.Duration  // Cursor blink interval
 	enableStatusBar bool           // Whether to show the status bar
+	waitReplace     bool           // Whether waiting for replace character
 
 	lineNumberStyle        lipgloss.Style
 	currentLineNumberStyle lipgloss.Style
@@ -348,6 +349,11 @@ func (m *editorModel) handleKeypress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else {
 			// Insert regular characters
 			if len(msg.String()) == 1 {
+				// if waitin for replace, insert and return to normal mode
+				if m.waitReplace {
+					m.waitReplace = false
+					return replaceCurrentCharacter(m, msg.String())
+				}
 				return insertCharacter(m, msg.String())
 			}
 		}


### PR DESCRIPTION
this is such a great model for bubbletea, thank you for making it.

implements bindings for "C" and "r" in normal mode.

- `C` simply deletes to end of line and enters insert mode
- `r` replaces current char with space, then replaces the space with next key press